### PR TITLE
t.Errorとt.Fatalの使い分け説明テーブルの見出しの位置のズレを修正

### DIFF
--- a/docs/testable-architecture-with-go-part1/index.html
+++ b/docs/testable-architecture-with-go-part1/index.html
@@ -327,7 +327,8 @@ ok  	github.dena.jp/swet/go-sampleapi/e2e	0.220s
 <h3 is-upgraded><code>t.Error</code>と<code>t.Fatal</code>の使い分け</h3>
 <p>Testが失敗した際 <code>t.Error</code>と<code>t.Fatal</code>の種類を使って表現していますが、Goにはtestを失敗させるために使う関数がいくつかあります。 以下にそれぞれの挙動の違いを載せます。</p>
 <table>
-<tr><td colspan="1" rowspan="1"><p>Testは失敗するか</p>
+<tr><td colspan="1" rowspan="1">
+</td><td colspan="1" rowspan="1"><p>Testは失敗するか</p>
 </td><td colspan="1" rowspan="1"><p>Testの実行がStopするか</p>
 </td><td colspan="1" rowspan="1"><p>失敗時にメッセージを出力できるか</p>
 </td></tr>


### PR DESCRIPTION
ドキュメントで気になった箇所があったのでPRを出させていただきました。

### [修正前]
![スクリーンショット 2021-03-16 3 33 30](https://user-images.githubusercontent.com/39585292/111203785-c4876500-8608-11eb-83ba-c00c6915dcd6.png)

### [修正後]
![スクリーンショット 2021-03-16 3 35 41](https://user-images.githubusercontent.com/39585292/111203848-d49f4480-8608-11eb-8ee9-2fe162754955.png)
