### PR TITLE
codelab用のcssとjsが置かれているパスの変更に追従(codelab-elements -> claat-public)

### DIFF
--- a/docs/android-ui-tests-basic/index.html
+++ b/docs/android-ui-tests-basic/index.html
@@ -9,7 +9,7 @@
   <title>Espressoの知識ゼロでも書ける！Android UIテストはじめの一歩</title>
   <link rel="stylesheet" href="//fonts.googleapis.com/css?family=Source+Code+Pro:400|Roboto:400,300,400italic,500,700|Roboto+Mono">
   <link rel="stylesheet" href="//fonts.googleapis.com/icon?family=Material+Icons">
-  <link rel="stylesheet" href="https://storage.googleapis.com/codelab-elements/codelab-elements.css">
+  <link rel="stylesheet" href="https://storage.googleapis.com/claat-public/codelab-elements.css">
   <link rel="stylesheet" href="../assets/style.css">
   <style>
       tbody tr:nth-child(1) {
@@ -768,10 +768,10 @@ fun assertPlanted(plantName: String) { .. }
     
   </google-codelab>
 
-  <script src="https://storage.googleapis.com/codelab-elements/native-shim.js"></script>
-  <script src="https://storage.googleapis.com/codelab-elements/custom-elements.min.js"></script>
-  <script src="https://storage.googleapis.com/codelab-elements/prettify.js"></script>
-  <script src="https://storage.googleapis.com/codelab-elements/codelab-elements.js"></script>
+  <script src="https://storage.googleapis.com/claat-public/native-shim.js"></script>
+  <script src="https://storage.googleapis.com/claat-public/custom-elements.min.js"></script>
+  <script src="https://storage.googleapis.com/claat-public/prettify.js"></script>
+  <script src="https://storage.googleapis.com/claat-public/codelab-elements.js"></script>
 
 </body>
 </html>

--- a/docs/android-ui-tests-espresso/index.html
+++ b/docs/android-ui-tests-espresso/index.html
@@ -9,7 +9,7 @@
   <title>Espresso APIを使いこなしてUIテストを書いてみよう</title>
   <link rel="stylesheet" href="//fonts.googleapis.com/css?family=Source+Code+Pro:400|Roboto:400,300,400italic,500,700|Roboto+Mono">
   <link rel="stylesheet" href="//fonts.googleapis.com/icon?family=Material+Icons">
-  <link rel="stylesheet" href="https://storage.googleapis.com/codelab-elements/codelab-elements.css">
+  <link rel="stylesheet" href="https://storage.googleapis.com/claat-public/codelab-elements.css">
   <link rel="stylesheet" href="../assets/style.css">
   <style>
       tbody tr:nth-child(2) {
@@ -923,10 +923,10 @@ fun test() {
     
   </google-codelab>
 
-  <script src="https://storage.googleapis.com/codelab-elements/native-shim.js"></script>
-  <script src="https://storage.googleapis.com/codelab-elements/custom-elements.min.js"></script>
-  <script src="https://storage.googleapis.com/codelab-elements/prettify.js"></script>
-  <script src="https://storage.googleapis.com/codelab-elements/codelab-elements.js"></script>
+  <script src="https://storage.googleapis.com/claat-public/native-shim.js"></script>
+  <script src="https://storage.googleapis.com/claat-public/custom-elements.min.js"></script>
+  <script src="https://storage.googleapis.com/claat-public/prettify.js"></script>
+  <script src="https://storage.googleapis.com/claat-public/codelab-elements.js"></script>
 
 </body>
 </html>

--- a/docs/encodingjson-generator/index.html
+++ b/docs/encodingjson-generator/index.html
@@ -9,7 +9,7 @@
   <title>JSONの変換をカスタマイズするメソッドを生成する</title>
   <link rel="stylesheet" href="//fonts.googleapis.com/css?family=Source+Code+Pro:400|Roboto:400,300,400italic,500,700|Roboto+Mono">
   <link rel="stylesheet" href="//fonts.googleapis.com/icon?family=Material+Icons">
-  <link rel="stylesheet" href="https://storage.googleapis.com/codelab-elements/codelab-elements.css">
+  <link rel="stylesheet" href="https://storage.googleapis.com/claat-public/codelab-elements.css">
   <link rel="stylesheet" href="../assets/style.css">
   <style>
     .success {
@@ -730,10 +730,10 @@ func (v *Resource) UnmarshalJSON(b []byte) error {
     
   <google-codelab-step label='感想・フィードバック' duration='2'><iframe src='https://docs.google.com/forms/d/e/1FAIpQLSd7oQL3N52g1ikIhFcO8Yb7PNgnMfxh6Vtbe1RuiOwII9qHZQ/viewform?entry.521550274=JSONの変換をカスタマイズするメソッドを生成する' width='640' height='1783' frameborder='0' marginheight='0' marginwidth='0'>Loading...</iframe></google-codelab-step></google-codelab>
 
-  <script src="https://storage.googleapis.com/codelab-elements/native-shim.js"></script>
-  <script src="https://storage.googleapis.com/codelab-elements/custom-elements.min.js"></script>
-  <script src="https://storage.googleapis.com/codelab-elements/prettify.js"></script>
-  <script src="https://storage.googleapis.com/codelab-elements/codelab-elements.js"></script>
+  <script src="https://storage.googleapis.com/claat-public/native-shim.js"></script>
+  <script src="https://storage.googleapis.com/claat-public/custom-elements.min.js"></script>
+  <script src="https://storage.googleapis.com/claat-public/prettify.js"></script>
+  <script src="https://storage.googleapis.com/claat-public/codelab-elements.js"></script>
 
 </body>
 </html>

--- a/docs/tdd-go/index.html
+++ b/docs/tdd-go/index.html
@@ -9,7 +9,7 @@
   <title>TDD（テスト駆動開発）で始めるGoのテスト</title>
   <link rel="stylesheet" href="//fonts.googleapis.com/css?family=Source+Code+Pro:400|Roboto:400,300,400italic,500,700|Roboto+Mono">
   <link rel="stylesheet" href="//fonts.googleapis.com/icon?family=Material+Icons">
-  <link rel="stylesheet" href="https://storage.googleapis.com/codelab-elements/codelab-elements.css">
+  <link rel="stylesheet" href="https://storage.googleapis.com/claat-public/codelab-elements.css">
   <link rel="stylesheet" href="../assets/style.css">
   <style>
     .success {
@@ -810,10 +810,10 @@ testFizzBuzz(t, tt.n, tt.expect) #L38</pre>
     
   <google-codelab-step label='感想・フィードバック' duration='2'><iframe src='https://docs.google.com/forms/d/e/1FAIpQLSd7oQL3N52g1ikIhFcO8Yb7PNgnMfxh6Vtbe1RuiOwII9qHZQ/viewform?entry.521550274=TDD（テスト駆動開発）で始めるGoのテスト' width='640' height='1783' frameborder='0' marginheight='0' marginwidth='0'>Loading...</iframe></google-codelab-step></google-codelab>
 
-  <script src="https://storage.googleapis.com/codelab-elements/native-shim.js"></script>
-  <script src="https://storage.googleapis.com/codelab-elements/custom-elements.min.js"></script>
-  <script src="https://storage.googleapis.com/codelab-elements/prettify.js"></script>
-  <script src="https://storage.googleapis.com/codelab-elements/codelab-elements.js"></script>
+  <script src="https://storage.googleapis.com/claat-public/native-shim.js"></script>
+  <script src="https://storage.googleapis.com/claat-public/custom-elements.min.js"></script>
+  <script src="https://storage.googleapis.com/claat-public/prettify.js"></script>
+  <script src="https://storage.googleapis.com/claat-public/codelab-elements.js"></script>
 
 </body>
 </html>

--- a/docs/testable-architecture-with-go-part1/index.html
+++ b/docs/testable-architecture-with-go-part1/index.html
@@ -9,7 +9,7 @@
   <title>テスタビリティの高いGoのAPIサーバを開発しよう（その1 ~準備&amp;E2E実装編~）</title>
   <link rel="stylesheet" href="//fonts.googleapis.com/css?family=Source+Code+Pro:400|Roboto:400,300,400italic,500,700|Roboto+Mono">
   <link rel="stylesheet" href="//fonts.googleapis.com/icon?family=Material+Icons">
-  <link rel="stylesheet" href="https://storage.googleapis.com/codelab-elements/codelab-elements.css">
+  <link rel="stylesheet" href="https://storage.googleapis.com/claat-public/codelab-elements.css">
 <link rel="stylesheet" href="../assets/style.css">
   <style>
     .success {
@@ -383,10 +383,10 @@ ok  	github.dena.jp/swet/go-sampleapi/e2e	0.220s
     
   </google-codelab>
 
-  <script src="https://storage.googleapis.com/codelab-elements/native-shim.js"></script>
-  <script src="https://storage.googleapis.com/codelab-elements/custom-elements.min.js"></script>
-  <script src="https://storage.googleapis.com/codelab-elements/prettify.js"></script>
-  <script src="https://storage.googleapis.com/codelab-elements/codelab-elements.js"></script>
+  <script src="https://storage.googleapis.com/claat-public/native-shim.js"></script>
+  <script src="https://storage.googleapis.com/claat-public/custom-elements.min.js"></script>
+  <script src="https://storage.googleapis.com/claat-public/prettify.js"></script>
+  <script src="https://storage.googleapis.com/claat-public/codelab-elements.js"></script>
   <script src="//support.google.com/inapp/api.js"></script>
 
 </body>

--- a/docs/testable-architecture-with-go-part2/index.html
+++ b/docs/testable-architecture-with-go-part2/index.html
@@ -9,7 +9,7 @@
   <title>テスタビリティの高いGoのAPIサーバを開発しよう（その2 ~リファクタ編~)</title>
   <link rel="stylesheet" href="//fonts.googleapis.com/css?family=Source+Code+Pro:400|Roboto:400,300,400italic,500,700|Roboto+Mono">
   <link rel="stylesheet" href="//fonts.googleapis.com/icon?family=Material+Icons">
-  <link rel="stylesheet" href="https://storage.googleapis.com/codelab-elements/codelab-elements.css">
+  <link rel="stylesheet" href="https://storage.googleapis.com/claat-public/codelab-elements.css">
 <link rel="stylesheet" href="../assets/style.css">
   <style>
     .success {
@@ -384,10 +384,10 @@ ok  	github.dena.jp/swet/go-sampleapi/e2e	0.222s
     
   </google-codelab>
 
-  <script src="https://storage.googleapis.com/codelab-elements/native-shim.js"></script>
-  <script src="https://storage.googleapis.com/codelab-elements/custom-elements.min.js"></script>
-  <script src="https://storage.googleapis.com/codelab-elements/prettify.js"></script>
-  <script src="https://storage.googleapis.com/codelab-elements/codelab-elements.js"></script>
+  <script src="https://storage.googleapis.com/claat-public/native-shim.js"></script>
+  <script src="https://storage.googleapis.com/claat-public/custom-elements.min.js"></script>
+  <script src="https://storage.googleapis.com/claat-public/prettify.js"></script>
+  <script src="https://storage.googleapis.com/claat-public/codelab-elements.js"></script>
   <script src="//support.google.com/inapp/api.js"></script>
 
 </body>

--- a/docs/testable-architecture-with-go-part3/index.html
+++ b/docs/testable-architecture-with-go-part3/index.html
@@ -9,7 +9,7 @@
   <title>テスタビリティの高いGoのAPIサーバを開発しよう（その3 ~テスト編~)</title>
   <link rel="stylesheet" href="//fonts.googleapis.com/css?family=Source+Code+Pro:400|Roboto:400,300,400italic,500,700|Roboto+Mono">
   <link rel="stylesheet" href="//fonts.googleapis.com/icon?family=Material+Icons">
-  <link rel="stylesheet" href="https://storage.googleapis.com/codelab-elements/codelab-elements.css">
+  <link rel="stylesheet" href="https://storage.googleapis.com/claat-public/codelab-elements.css">
 <link rel="stylesheet" href="../assets/style.css">
   <style>
     .success {
@@ -411,10 +411,10 @@ ok      github.dena.jp/swet/go-sampleapi/internal/repository   0.068s
     
   </google-codelab>
 
-  <script src="https://storage.googleapis.com/codelab-elements/native-shim.js"></script>
-  <script src="https://storage.googleapis.com/codelab-elements/custom-elements.min.js"></script>
-  <script src="https://storage.googleapis.com/codelab-elements/prettify.js"></script>
-  <script src="https://storage.googleapis.com/codelab-elements/codelab-elements.js"></script>
+  <script src="https://storage.googleapis.com/claat-public/native-shim.js"></script>
+  <script src="https://storage.googleapis.com/claat-public/custom-elements.min.js"></script>
+  <script src="https://storage.googleapis.com/claat-public/prettify.js"></script>
+  <script src="https://storage.googleapis.com/claat-public/codelab-elements.js"></script>
   <script src="//support.google.com/inapp/api.js"></script>
 
 </body>


### PR DESCRIPTION
<!-- Please write a description of this pull request.  -->

---

### Contribution License Agreement

<!-- Please accept the Contributor License Agreement to submit the pull requst. --> 

- [x] By placing an "x" in the box, I hereby understand, accept and agree to be bound by the terms and conditions of the [Contribution License Agreement](https://dena.github.io/cla/).


利用していたcssが空のhtmlを返すようになっていたため、パスを変更しました
各codelabのindex.htmlがcodelabぽい見た目になったことを確認しました

![image](https://github.com/DeNA/codelabs/assets/3140018/394e3c9f-7d68-4c81-90e4-8eacadc130d0)
